### PR TITLE
Upgrade to node 21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM node:20 as FRONTEND
+FROM --platform=$BUILDPLATFORM node:21 as FRONTEND
 
 WORKDIR /usr/src/app
 
@@ -11,7 +11,7 @@ COPY packages/frontend packages/frontend
 
 RUN npm run build -w frontend
 
-FROM node:20 as DEPENDENCIES
+FROM node:21 as DEPENDENCIES
 
 WORKDIR /usr/src/app
 
@@ -32,7 +32,7 @@ RUN --mount=type=cache,target=/root/.npm npm ci --omit=dev --no-audit --no-fund
 
 COPY . .
 
-FROM node:20-slim as TARGET
+FROM node:21-slim as TARGET
 
 ENV NODE_ENV production
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - MYSQL_DATABASE=argus
       - MYSQL_ALLOW_EMPTY_PASSWORD=true
   backend:
-    image: node:20
+    image: node:21
     env_file: .env
     volumes:
       - .:/opt/app:delegated
@@ -25,7 +25,7 @@ services:
     depends_on:
       - mariadb
   frontend:
-    image: node:20
+    image: node:21
     volumes:
       - .:/opt/app:delegated
     working_dir: /opt/app

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,8 +18,8 @@
         "prettier": "^3.2.5"
       },
       "engines": {
-        "node": "^20.0.0",
-        "npm": ">9.0.0"
+        "node": "^21.0.0",
+        "npm": ">10.0.0"
       }
     },
     "node_modules/@abandonware/bluetooth-hci-socket": {
@@ -8423,13 +8423,13 @@
       }
     },
     "node_modules/i2c-bus": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/i2c-bus/-/i2c-bus-5.2.2.tgz",
-      "integrity": "sha512-b2y/et08rqggEjqod6QxV0Ng+RlSkZXsdE+E1aZEQBahepZ9uFD9XfA77Y8O9SgyhwfGEn+CNxsw0gvXW1/m4g==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/i2c-bus/-/i2c-bus-5.2.3.tgz",
+      "integrity": "sha512-kzFgU0OSIZlaeUUa+VK7L+kkxnj4feimCVQDOPrzj0cTaB+hNweTsO8/j7QvW2gRgWQ7ds5IpfFjpBrX+fMNng==",
       "hasInstallScript": true,
       "dependencies": {
         "bindings": "^1.5.0",
-        "nan": "^2.14.2"
+        "nan": "^2.17.0"
       },
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -5,11 +5,11 @@
   "license": "MIT",
   "type": "module",
   "engines": {
-    "node": "^20.0.0",
-    "npm": ">9.0.0"
+    "node": "^21.0.0",
+    "npm": ">10.0.0"
   },
   "volta": {
-    "node": "20.5.1"
+    "node": "21.0.0"
   },
   "scripts": {
     "build": "npm run build -w frontend",


### PR DESCRIPTION
Two incompatible packages:
* [epoll](https://github.com/fivdi/epoll)
* [i2c-bus](https://github.com/fivdi/i2c-bus)

```
$ npm list epoll
argus@
└─┬ hcsr501@ -> ./packages/clients/hcsr501
  └─┬ onoff@6.0.3
    └── epoll@4.0.1
```

```
$ npm list i2c-bus
argus@
└─┬ bme280@ -> ./packages/clients/bme280
  └─┬ bme280-sensor@0.1.7
    └── i2c-bus@5.2.2
```